### PR TITLE
Fix rectangle_shape#set_size

### DIFF
--- a/OcsfmlGraphics/ocsfmlGraphics.ml
+++ b/OcsfmlGraphics/ocsfmlGraphics.ml
@@ -1510,7 +1510,7 @@ struct
   external from_size : (float * float) -> t =
       "sf_RectangleShape_size_constructor__impl"
 	
-  external set_size : t -> (float * float) =
+  external set_size : t -> (float * float) -> unit =
       "sf_RectangleShape_setSize__impl"
 	
   external get_size : t -> (float * float) =
@@ -1527,7 +1527,7 @@ object ((self : 'self))
 
   method destroy = RectangleShape.destroy t_rectangle_shape_base
 
-  method set_size : (float * float) =
+  method set_size : (float * float) -> unit =
     RectangleShape.set_size t_rectangle_shape_base
 
   method get_size : (float * float) =

--- a/OcsfmlGraphics/ocsfmlGraphics.mli
+++ b/OcsfmlGraphics/ocsfmlGraphics.mli
@@ -2450,7 +2450,7 @@ sig
   val to_shape : t -> Shape.t
   val default : unit -> t
   val from_size : float * float -> t
-  val set_size : t -> float * float
+  val set_size : t -> (float * float) -> unit
   val get_size : t -> float * float
 end
   (**/**)
@@ -2492,16 +2492,16 @@ object
   (**)
   method destroy : unit
 
-  (** Set the size of the rectangle. *)
+  (** Get the size of the rectangle. 
+      @return Size of the rectangle. *)
   method get_size : float * float
 
   (**/**)
   method rep__sf_RectangleShape : RectangleShape.t
     (**/**)
 
-  (** Get the size of the rectangle. 
-      @return Size of the rectangle. *)
-  method set_size : float * float
+  (** Set the size of the rectangle. *)
+  method set_size : (float * float) -> unit
 end
 
 


### PR DESCRIPTION
It had the same signature as `get_size`. Now it doesn't, and it looks like it works.
